### PR TITLE
Update PngModule.java

### DIFF
--- a/extramodules/it/eng/jhove/module/png/PngModule.java
+++ b/extramodules/it/eng/jhove/module/png/PngModule.java
@@ -370,7 +370,7 @@ public class PngModule extends ModuleBase {
 										   IdentifierType.URL));
 		_specification.add (doc);
 
-		Signature sig = new InternalSignature ("PNG", SignatureType.MAGIC,
+		Signature sig = new InternalSignature (COVERAGE, SignatureType.MAGIC,
 											   SignatureUseType.MANDATORY, 0);
 		_signature.add (sig);
 
@@ -385,7 +385,7 @@ public class PngModule extends ModuleBase {
 			repInfo.setWellFormed (RepInfo.FALSE);
 			return 0;
 		}
-		repInfo.setFormat("PNG");
+		repInfo.setFormat(COVERAGE);
 
 		// If we got this far, take note that the signature is OK.
 		repInfo.setSigMatch(_name);


### PR DESCRIPTION
Constant COVERAGE set as "PNG"; made 2 replacements of literal "PNG" with COVERAGE
Left 2 occurences of " no ancora standardizzato dal W3C."