### PR TITLE
Update WaveModule.java

### DIFF
--- a/jhove-modules/wave-hul/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
+++ b/jhove-modules/wave-hul/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
@@ -88,6 +88,7 @@ public class WaveModule extends ModuleBase {
     private static final String RIGHTS = "Copyright 2004-2007 by JSTOR and the "
             + "President and Fellows of Harvard College. "
             + "Released under the GNU Lesser General Public License.";
+    private static final String MSLIB_URL = "http://msdn.microsoft.com/library/default.asp?url=/library/en-us/"
 
     /** Fixed value for first four bytes of WAVE files */
     private static final String RIFF_SIGNATURE = "RIFF";
@@ -222,24 +223,21 @@ public class WaveModule extends ModuleBase {
 
 		Document doc = new Document("PCMWAVEFORMAT", DocumentType.WEB);
 		doc.setIdentifier(new Identifier(
-				"http://msdn.microsoft.com/library/default.asp?url=/library/en-us/"
-						+ "multimed/htm/_win32_pcmwaveformat_str.asp",
+				MSLIB_URL + "multimed/htm/_win32_pcmwaveformat_str.asp",
 				IdentifierType.URL));
 		doc.setPublisher(msAgent);
 		_specification.add(doc);
 
 		doc = new Document("WAVEFORMATEX", DocumentType.WEB);
 		doc.setIdentifier(new Identifier(
-				"http://msdn.microsoft.com/library/default.asp?url=/library/en-us/"
-						+ "multimed/htm/_win32_waveformatex_str.asp",
+				MSLIB_URL + "multimed/htm/_win32_waveformatex_str.asp",
 				IdentifierType.URL));
 		doc.setPublisher(msAgent);
 		_specification.add(doc);
 
 		doc = new Document("WAVEFORMATEXTENSIBLE", DocumentType.WEB);
 		doc.setIdentifier(new Identifier(
-				"http://msdn.microsoft.com/library/default.asp?url=/library/en-us/"
-						+ "multimed/htm/_win32_waveformatextensible_str.asp",
+				MSLIB_URL + "multimed/htm/_win32_waveformatextensible_str.asp",
 				IdentifierType.URL));
 		doc.setPublisher(msAgent);
 		_specification.add(doc);
@@ -254,7 +252,7 @@ public class WaveModule extends ModuleBase {
 
 		doc = new Document("Specification of the Broadcast Wave Format (BWF)",
 				DocumentType.REPORT);
-		doc.setIdentifier(new Identifier("EBU Technical Specification 3285",
+		doc.setIdentifier(new Identifier(FORMAT[2],
 				IdentifierType.OTHER));
 		doc.setIdentifier(
 				new Identifier("https://tech.ebu.ch/docs/tech/tech3285.pdf",
@@ -265,7 +263,7 @@ public class WaveModule extends ModuleBase {
 
 		doc = new Document("MBWF / RF64: An Extended File Format for Audio",
 				DocumentType.REPORT);
-		doc.setIdentifier(new Identifier("EBU Technical Specification 3306",
+		doc.setIdentifier(new Identifier(FORMAT[5],
 				IdentifierType.OTHER));
 		doc.setIdentifier(new Identifier(
 				"https://tech.ebu.ch/docs/tech/tech3306-2009.pdf",
@@ -297,7 +295,7 @@ public class WaveModule extends ModuleBase {
 				SignatureUseType.OPTIONAL, "For RF64 profile");
 		_signature.add(sig);
 
-		sig = new InternalSignature("RIFF", SignatureType.MAGIC,
+		sig = new InternalSignature(RIFF_SIGNATURE, SignatureType.MAGIC,
 				SignatureUseType.MANDATORY_IF_APPLICABLE, 0);
 		_signature.add(sig);
 
@@ -305,7 +303,7 @@ public class WaveModule extends ModuleBase {
 				SignatureUseType.MANDATORY_IF_APPLICABLE, 0);
 		_signature.add(sig);
 
-		sig = new InternalSignature("WAVE", SignatureType.MAGIC,
+		sig = new InternalSignature(FORMATS[0], SignatureType.MAGIC,
 				SignatureUseType.MANDATORY, 8);
 		_signature.add(sig);
 
@@ -363,7 +361,7 @@ public class WaveModule extends ModuleBase {
 
 			// Read the RIFF form type
 			String formType = read4Chars(_dstream);
-			if (!"WAVE".equals(formType)) {
+			if (!FORMAT[0].equals(formType)) {
 				info.setMessage(new ErrorMessage(
 						MessageConstants.WAVE_HUL_2,
 						_nByte - RIFF_FORM_TYPE_LENGTH));
@@ -680,7 +678,7 @@ public class WaveModule extends ModuleBase {
 		_aesMetadata = new AESAudioMetadata();
 		_aesMetadata.setByteOrder(AESAudioMetadata.LITTLE_ENDIAN);
 		_aesMetadata.setAnalogDigitalFlag("FILE_DIGITAL");
-		_aesMetadata.setFormat("WAVE");
+		_aesMetadata.setFormat(FORMAT[0]);
 		_aesMetadata.setUse("OTHER", "JHOVE_validation");
 		_aesMetadata.setDirection("NONE");
 


### PR DESCRIPTION
Replaced 4 string literals with declared constants ("WAVE", "EBU Technical Specification 3285" && "...3306", "RIFF")
Created constant MSLIB_URL to define recurring document identifier element ("http://msdn.microsoft.com/library/default.asp?url=/library/en-us/"); replaced 3 instances of literal.
Ignored 3 string literals that were undeclared and appeared only twice ("PCMWAVEFORMAT", "WAVEFORMATEX", "WAVEFORMATEXTENSIBLE")